### PR TITLE
Fix expired bucket having infinite tokens

### DIFF
--- a/src/lib/server/rate-limit.ts
+++ b/src/lib/server/rate-limit.ts
@@ -115,6 +115,7 @@ export class ExpiringTokenBucket<_Key> {
 			return true;
 		}
 		if (now - bucket.createdAt >= this.expiresInSeconds * 1000) {
+			bucket.createdAt = now;
 			bucket.count = this.max;
 		}
 		if (bucket.count < cost) {


### PR DESCRIPTION
Since `createdAt` was not updated on expiration, it was possible to consume infinite tokens (up to a `max` at a time) after bucket expiration.